### PR TITLE
No-Jira: add support for passing a mapping into parsing helpers

### DIFF
--- a/lib/parameter_substitution.rb
+++ b/lib/parameter_substitution.rb
@@ -64,18 +64,18 @@ class ParameterSubstitution
       ParameterSubstitution.config = config
     end
 
-    def find_tokens(string_with_tokens)
-      parse_expression(context_from_string(string_with_tokens)).substitution_parameter_names
+    def find_tokens(string_with_tokens, mapping: {})
+      parse_expression(context_from_string(string_with_tokens, mapping)).substitution_parameter_names
     end
 
-    def find_formatters(string_with_tokens)
-      parse_expression(context_from_string(string_with_tokens)).method_names
+    def find_formatters(string_with_tokens, mapping: {})
+      parse_expression(context_from_string(string_with_tokens, mapping)).method_names
     end
 
     private
 
-    def context_from_string(string_with_tokens)
-      ParameterSubstitution::Context.new(input: string_with_tokens, mapping: [])
+    def context_from_string(string_with_tokens, mapping)
+      ParameterSubstitution::Context.new(input: string_with_tokens, mapping: mapping)
     end
 
     def parse_expression(context)

--- a/spec/lib/parameter_substitution_spec.rb
+++ b/spec/lib/parameter_substitution_spec.rb
@@ -74,7 +74,7 @@ describe ParameterSubstitution do
       let(:mapping) { { 'call.start_time' => 'hello' } }
 
       context "#find_tokens" do
-        it "returns tokens up to first dot when now mapping is provided" do
+        it "returns tokens up to first dot when no mapping is provided" do
           expect(ParameterSubstitution.find_tokens(expression)).to eq(['call', 'do_a_barrel_roll'])
         end
 

--- a/spec/lib/parameter_substitution_spec.rb
+++ b/spec/lib/parameter_substitution_spec.rb
@@ -69,19 +69,34 @@ describe ParameterSubstitution do
       }
     end
 
+    context "parsing helpers" do
+      let(:expression) { "<call.start_time.blank_if_nil><do_a_barrel_roll.downcase>" }
+      let(:mapping) { { 'call.start_time' => 'hello' } }
+
+      context "#find_tokens" do
+        it "returns tokens up to first dot when now mapping is provided" do
+          expect(ParameterSubstitution.find_tokens(expression)).to eq(['call', 'do_a_barrel_roll'])
+        end
+
+        it "returns tokens that exist in mapping when one is provided" do
+          expect(ParameterSubstitution.find_tokens(expression, mapping: mapping)).to eq(['call.start_time', 'do_a_barrel_roll'])
+        end
+      end
+
+      context '#find_formatters' do
+        it "returns all formatters after first dot when no mapping is provided" do
+          expect(ParameterSubstitution.find_formatters(expression)).to eq(['start_time', 'blank_if_nil', 'downcase'])
+        end
+
+        it "returns formatters after all tokens when mapping is provided" do
+          expect(ParameterSubstitution.find_formatters(expression, mapping: mapping)).to eq(['blank_if_nil', 'downcase'])
+        end
+      end
+    end
+
     it "handle simple go right cases" do
       assert_parse_result ".bar.", ".<foo.downcase>."
       assert_parse_result ".bar.", ".<foo.downcase()>."
-    end
-
-    it "finds tokens in a string" do
-      result = ParameterSubstitution.find_tokens("<foo><do_a_barrel_roll>")
-      expect(result).to eq(["foo","do_a_barrel_roll"])
-    end
-
-    it "finds formatters in a string" do
-      result = ParameterSubstitution.find_formatters("<foo.do_a_barrel_roll><foo2.downcase>")
-      expect(result).to eq(["do_a_barrel_roll", "downcase"])
     end
 
     it "work with escaped parameter names" do


### PR DESCRIPTION
When parsing an expression, it's important to have the mapping of available variables in the context so that the parser knows what variables exists.  This is adding support for taking in an optional mapping to the helper methods `find_tokens` and `find_formatters`, allowing for more accurate detection of tokens and formatters.