### PR TITLE
1912/story 7828 improve substitution params errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parameter_substitution (0.2.2)
+    parameter_substitution (0.2.3)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/parameter_substitution.rb
+++ b/lib/parameter_substitution.rb
@@ -25,9 +25,6 @@ class ParameterSubstitution
 
   cattr_accessor :config
 
-  UNKNOWN_PARAM_WARNING_TYPE  = :unknown_param_warning_type
-  UNKNOWN_METHOD_WARNING_TYPE = :unknown_method_warning_type
-
   class << self
     def evaluate(
       input:,

--- a/lib/parameter_substitution.rb
+++ b/lib/parameter_substitution.rb
@@ -51,9 +51,9 @@ class ParameterSubstitution
 
       expression = parse_expression(context)
       expression.validate
-      [expression.evaluate, expression.warnings, expression.paramter_and_method_warnings]
+      [expression.evaluate, expression.warnings, expression.parameter_and_method_warnings]
     rescue ParameterSubstitution::ParseError => ex
-      [context.input, ex.message, expression&.paramter_and_method_warnings]
+      [context.input, ex.message, expression&.parameter_and_method_warnings]
     rescue => ex
       raise SubstitutionError, "Error occurred while parameter substitution: #{ex.message}"
     end
@@ -73,7 +73,7 @@ class ParameterSubstitution
     end
 
     def find_warnings(string_with_tokens, mapping: {}, warning_type: nil)
-      parse_expression(context_from_string(string_with_tokens, mapping)).paramter_and_method_warnings(warning_type) || []
+      parse_expression(context_from_string(string_with_tokens, mapping)).parameter_and_method_warnings(warning_type) || []
     end
 
     private

--- a/lib/parameter_substitution.rb
+++ b/lib/parameter_substitution.rb
@@ -72,8 +72,8 @@ class ParameterSubstitution
       parse_expression(context_from_string(string_with_tokens, mapping)).method_names
     end
 
-    def find_warnings(string_with_tokens, mapping: {}, warning_type: nil)
-      parse_expression(context_from_string(string_with_tokens, mapping)).parameter_and_method_warnings(warning_type) || []
+    def find_warnings(string_with_tokens, mapping: {})
+      parse_expression(context_from_string(string_with_tokens, mapping)).parameter_and_method_warnings || []
     end
 
     private

--- a/lib/parameter_substitution.rb
+++ b/lib/parameter_substitution.rb
@@ -50,6 +50,7 @@ class ParameterSubstitution
       )
 
       expression = parse_expression(context)
+
       expression.validate
       [expression.evaluate, expression.warnings]
     rescue ParameterSubstitution::ParseError => ex
@@ -70,6 +71,10 @@ class ParameterSubstitution
 
     def find_formatters(string_with_tokens, mapping: {})
       parse_expression(context_from_string(string_with_tokens, mapping)).method_names
+    end
+
+    def find_warnings(string_with_tokens, mapping: {})
+      parse_expression(context_from_string(string_with_tokens, mapping)).warnings
     end
 
     private

--- a/lib/parameter_substitution.rb
+++ b/lib/parameter_substitution.rb
@@ -53,11 +53,10 @@ class ParameterSubstitution
       )
 
       expression = parse_expression(context)
-
       expression.validate
-      [expression.evaluate, expression.warnings&.join(", ")]
+      [expression.evaluate, expression.warnings, expression.paramter_and_method_warnings]
     rescue ParameterSubstitution::ParseError => ex
-      [context.input, ex.message]
+      [context.input, ex.message, expression&.paramter_and_method_warnings]
     rescue => ex
       raise SubstitutionError, "Error occurred while parameter substitution: #{ex.message}"
     end
@@ -77,7 +76,7 @@ class ParameterSubstitution
     end
 
     def find_warnings(string_with_tokens, mapping: {}, warning_type: nil)
-      parse_expression(context_from_string(string_with_tokens, mapping)).warnings(warning_type) || []
+      parse_expression(context_from_string(string_with_tokens, mapping)).paramter_and_method_warnings(warning_type) || []
     end
 
     private

--- a/lib/parameter_substitution.rb
+++ b/lib/parameter_substitution.rb
@@ -25,6 +25,9 @@ class ParameterSubstitution
 
   cattr_accessor :config
 
+  UNKNOWN_PARAM_WARNING_TYPE  = :unknown_param_warning_type
+  UNKNOWN_METHOD_WARNING_TYPE = :unknown_method_warning_type
+
   class << self
     def evaluate(
       input:,
@@ -73,8 +76,8 @@ class ParameterSubstitution
       parse_expression(context_from_string(string_with_tokens, mapping)).method_names
     end
 
-    def find_warnings(string_with_tokens, mapping: {})
-      parse_expression(context_from_string(string_with_tokens, mapping)).warnings
+    def find_warnings(string_with_tokens, mapping: {}, warning_type: nil)
+      parse_expression(context_from_string(string_with_tokens, mapping)).warnings(warning_type)
     end
 
     private

--- a/lib/parameter_substitution.rb
+++ b/lib/parameter_substitution.rb
@@ -55,7 +55,7 @@ class ParameterSubstitution
       expression = parse_expression(context)
 
       expression.validate
-      [expression.evaluate, expression.warnings]
+      [expression.evaluate, expression.warnings&.join(", ")]
     rescue ParameterSubstitution::ParseError => ex
       [context.input, ex.message]
     rescue => ex
@@ -77,7 +77,7 @@ class ParameterSubstitution
     end
 
     def find_warnings(string_with_tokens, mapping: {}, warning_type: nil)
-      parse_expression(context_from_string(string_with_tokens, mapping)).warnings(warning_type)
+      parse_expression(context_from_string(string_with_tokens, mapping)).warnings(warning_type) || []
     end
 
     private

--- a/lib/parameter_substitution/expression.rb
+++ b/lib/parameter_substitution/expression.rb
@@ -95,7 +95,7 @@ class ParameterSubstitution
       unknown_parameter_methods.map_compact do |param, methods|
         method_string = "method#{methods.size > 1 ? 's' : ''}"
         if !(methods.empty? || unknown_parameters.include?(param))
-          "Unknown #{method_string} #{@context.formatted_arg_list(methods)} used for on parameter '#{param}'"
+          "Unknown #{method_string} #{@context.formatted_arg_list(methods)} used on parameter '#{param}'"
         end
       end
     end

--- a/lib/parameter_substitution/expression.rb
+++ b/lib/parameter_substitution/expression.rb
@@ -35,11 +35,11 @@ class ParameterSubstitution
     def warnings(warning_type = nil)
       if warning_type.nil?
         unknown_messages = unknown_parameter_messages + unknown_method_messages
-        unknown_messages.empty? ? nil : unknown_messages
+        unknown_messages.empty? ? nil : unknown_messages.uniq
       elsif warning_type == UNKNOWN_PARAM_WARNING_TYPE
-        unknown_parameter_messages
+        unknown_parameter_messages.uniq
       elsif warning_type == UNKNOWN_METHOD_WARNING_TYPE
-        unknown_method_messages
+        unknown_method_messages.uniq
       end
     end
 

--- a/lib/parameter_substitution/expression.rb
+++ b/lib/parameter_substitution/expression.rb
@@ -36,7 +36,7 @@ class ParameterSubstitution
       unknown_parameters_message
     end
 
-    def paramter_and_method_warnings(warning_type = nil)
+    def parameter_and_method_warnings(warning_type = nil)
       if warning_type.nil?
         unknown_messages = unknown_parameter_messages + unknown_method_messages
         unknown_messages.empty? ? nil : unknown_messages.uniq

--- a/lib/parameter_substitution/expression.rb
+++ b/lib/parameter_substitution/expression.rb
@@ -6,9 +6,6 @@ class ParameterSubstitution
   class Expression
     attr_reader :expression_list, :context
 
-    UNKNOWN_PARAM_WARNING_TYPE  = :unknown_param_warning_type
-    UNKNOWN_METHOD_WARNING_TYPE = :unknown_method_warning_type
-
     def initialize(expression_list, context)
       @expression_list = expression_list
       @context = context

--- a/lib/parameter_substitution/expression.rb
+++ b/lib/parameter_substitution/expression.rb
@@ -138,10 +138,13 @@ class ParameterSubstitution
     def unknown_parameter_methods
       @expression_list.select(&:parameter_name).reduce({}) do |hash, expression|
         hash[expression.parameter_name] ||= []
-        hash[expression.parameter_name]
-          .push(*(methods_used_by_expression(expression) - ParameterSubstitution::Formatters::Manager.all_formats.map { |k, _v| k.to_s }))
+        hash[expression.parameter_name].push(*missing_methods(expression))
         hash
       end
+    end
+
+    def missing_methods(expression)
+      (methods_used_by_expression(expression) - ParameterSubstitution::Formatters::Manager.all_formats.map { |k, _v| k.to_s })
     end
   end
 end

--- a/lib/parameter_substitution/expression.rb
+++ b/lib/parameter_substitution/expression.rb
@@ -32,7 +32,11 @@ class ParameterSubstitution
       end
     end
 
-    def warnings(warning_type = nil)
+    def warnings
+      unknown_parameters_message
+    end
+
+    def paramter_and_method_warnings(warning_type = nil)
       if warning_type.nil?
         unknown_messages = unknown_parameter_messages + unknown_method_messages
         unknown_messages.empty? ? nil : unknown_messages.uniq

--- a/lib/parameter_substitution/expression.rb
+++ b/lib/parameter_substitution/expression.rb
@@ -95,7 +95,7 @@ class ParameterSubstitution
     def unknown_method_messages
       unknown_parameter_methods.map_compact do |param, methods|
         method_string = pluralize_text("method", methods.size)
-        if !(methods.empty? || unknown_parameters.include?(param))
+        unless methods.empty? || unknown_parameters.include?(param)
           "Unknown #{method_string} #{@context.formatted_arg_list(methods)} used on parameter '#{param}'"
         end
       end

--- a/lib/parameter_substitution/expression.rb
+++ b/lib/parameter_substitution/expression.rb
@@ -73,7 +73,8 @@ class ParameterSubstitution
       matched_parameters = substitution_parameter_names.uniq
       required_parameters = @context.required_parameters
       if !required_parameters.empty? && (missing_fields = required_parameters.reject { |rt| rt.in?(matched_parameters) }).any?
-        raise ParameterSubstitution::ParseError, "The following field#{missing_fields.size > 1 ? 's' : ''} must be included: #{@context.formatted_arg_list(missing_fields)}"
+        raise ParameterSubstitution::ParseError,
+              "The following #{pluralize_text("field", missing_fields.size)} must be included: #{@context.formatted_arg_list(missing_fields)}"
       end
     end
 
@@ -93,7 +94,7 @@ class ParameterSubstitution
 
     def unknown_method_messages
       unknown_parameter_methods.map_compact do |param, methods|
-        method_string = "method#{methods.size > 1 ? 's' : ''}"
+        method_string = pluralize_text("method", methods.size)
         if !(methods.empty? || unknown_parameters.include?(param))
           "Unknown #{method_string} #{@context.formatted_arg_list(methods)} used on parameter '#{param}'"
         end
@@ -103,7 +104,7 @@ class ParameterSubstitution
     def unknown_parameter_messages
       unknown_parameters.map do |param|
         unknown_methods_for_param = unknown_parameter_methods[param]
-        method_string = "method#{unknown_methods_for_param.size > 1 ? 's' : ''}"
+        method_string = pluralize_text("method", unknown_methods_for_param.size)
         unknown_method_message = if unknown_methods_for_param.empty?
                                    ''
                                  else
@@ -115,7 +116,7 @@ class ParameterSubstitution
 
     def unknown_parameters_message
       unless unknown_parameters.empty?
-        "Unknown replacement parameter#{unknown_parameters.size > 1 ? 's' : ''} #{@context.formatted_arg_list(unknown_parameters)}"
+        "Unknown replacement #{pluralize_text("parameter", unknown_parameters.size)} #{@context.formatted_arg_list(unknown_parameters)}"
       end
     end
 
@@ -145,6 +146,10 @@ class ParameterSubstitution
 
     def missing_methods(expression)
       (methods_used_by_expression(expression) - ParameterSubstitution::Formatters::Manager.all_formats.map { |k, _v| k.to_s })
+    end
+
+    def pluralize_text(text, amount)
+      text + (amount > 1 ? 's' : '')
     end
   end
 end

--- a/lib/parameter_substitution/expression.rb
+++ b/lib/parameter_substitution/expression.rb
@@ -36,15 +36,9 @@ class ParameterSubstitution
       unknown_parameters_message
     end
 
-    def parameter_and_method_warnings(warning_type = nil)
-      if warning_type.nil?
-        unknown_messages = unknown_parameter_messages + unknown_method_messages
-        unknown_messages.empty? ? nil : unknown_messages.uniq
-      elsif warning_type == UNKNOWN_PARAM_WARNING_TYPE
-        unknown_parameter_messages.uniq
-      elsif warning_type == UNKNOWN_METHOD_WARNING_TYPE
-        unknown_method_messages.uniq
-      end
+    def parameter_and_method_warnings
+      unknown_messages = unknown_parameter_messages + unknown_method_messages
+      unknown_messages.empty? ? nil : unknown_messages.uniq
     end
 
     def substitution_parameter_names

--- a/lib/parameter_substitution/expression.rb
+++ b/lib/parameter_substitution/expression.rb
@@ -6,6 +6,9 @@ class ParameterSubstitution
   class Expression
     attr_reader :expression_list, :context
 
+    UNKNOWN_PARAM_WARNING_TYPE  = :unknown_param_warning_type
+    UNKNOWN_METHOD_WARNING_TYPE = :unknown_method_warning_type
+
     def initialize(expression_list, context)
       @expression_list = expression_list
       @context = context
@@ -29,9 +32,15 @@ class ParameterSubstitution
       end
     end
 
-    def warnings
-      unknown_messages = unknown_parameter_messages + unknown_method_messages
-      unknown_messages.empty? ? nil : unknown_messages
+    def warnings(warning_type = nil)
+      if warning_type.nil?
+        unknown_messages = unknown_parameter_messages + unknown_method_messages
+        unknown_messages.empty? ? nil : unknown_messages
+      elsif warning_type == UNKNOWN_PARAM_WARNING_TYPE
+        unknown_parameter_messages
+      elsif warning_type == UNKNOWN_METHOD_WARNING_TYPE
+        unknown_method_messages
+      end
     end
 
     def substitution_parameter_names

--- a/parameter_substitution.gemspec
+++ b/parameter_substitution.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name         = "parameter_substitution"
-  spec.version      = "0.2.2"
+  spec.version      = "0.2.3"
   spec.authors      = ["Bob Smith", "James Ebentier"]
   spec.email        = ["bob@invoca.com", "jebentier@invoca.com", "cmcgrath@invoca.com"]
 

--- a/spec/lib/parameter_substitution/expression_spec.rb
+++ b/spec/lib/parameter_substitution/expression_spec.rb
@@ -97,7 +97,7 @@ describe ParameterSubstitution::Expression do
       let(:expression_with_mixed_bad_params_and_methods) { "<bobby.test1.test2><color.test3.test4>" }
 
       context "when parameters are valid" do
-        it "returns empty array" do
+        it "returns nil" do
           expect(parse_expression(expression_with_valid_params).parameter_and_method_warnings)
             .to eq(nil)
         end
@@ -111,7 +111,7 @@ describe ParameterSubstitution::Expression do
       end
 
       context "when warning_type is :unknown_method_warning_type" do
-        it "returns 2 warnings" do
+        it "returns 1 warnings" do
           expect(parse_expression(expression_with_mixed_bad_params_and_methods).parameter_and_method_warnings(:unknown_method_warning_type))
             .to eq(["Unknown methods 'test3', 'test4' used on parameter 'color'"])
         end

--- a/spec/lib/parameter_substitution/expression_spec.rb
+++ b/spec/lib/parameter_substitution/expression_spec.rb
@@ -113,7 +113,7 @@ describe ParameterSubstitution::Expression do
       context "when warning_type is :unknown_method_warning_type" do
         it "returns 2 warnings" do
           expect(parse_expression(expression_with_mixed_bad_params_and_methods).parameter_and_method_warnings(:unknown_method_warning_type))
-            .to eq(["Unknown methods 'test3', 'test4' used for on parameter 'color'"])
+            .to eq(["Unknown methods 'test3', 'test4' used on parameter 'color'"])
         end
       end
 
@@ -126,8 +126,8 @@ describe ParameterSubstitution::Expression do
       context "when there are invalid methods" do
         it "returns 2 warnings" do
           expect(parse_expression(expression_with_bad_methods).parameter_and_method_warnings)
-            .to eq(["Unknown methods 'test1', 'test2', 'test3', 'test4' used for on parameter 'color'",
-                    "Unknown methods 'test1', 'test2' used for on parameter 'size'"])
+            .to eq(["Unknown methods 'test1', 'test2', 'test3', 'test4' used on parameter 'color'",
+                    "Unknown methods 'test1', 'test2' used on parameter 'size'"])
         end
       end
 

--- a/spec/lib/parameter_substitution/expression_spec.rb
+++ b/spec/lib/parameter_substitution/expression_spec.rb
@@ -88,5 +88,55 @@ describe ParameterSubstitution::Expression do
         expect(expression.method_names).to eq(["method"])
       end
     end
+
+    context '#parameter_and_method_warnings' do
+      let(:expression_with_valid_params) { "<color>" }
+      let(:expression_with_bad_paramss) { "<bobby><bobby2>" }
+      let(:expression_with_bad_methods) { "<color.test1.test2><color.test3.test4><size.test1.test2>" }
+      let(:expression_with_bad_params_and_methods) { "<bobby.test1.test2><bobby2.test3.test4>" }
+      let(:expression_with_mixed_bad_params_and_methods) { "<bobby.test1.test2><color.test3.test4>" }
+
+      context "when parameters are valid" do
+        it "returns empty array" do
+          expect(parse_expression(expression_with_valid_params).parameter_and_method_warnings)
+            .to eq(nil)
+        end
+      end
+
+      context "when warning_type is :unknown_param_warning_type" do
+        it "returns 1 warnings" do
+          expect(parse_expression(expression_with_mixed_bad_params_and_methods).parameter_and_method_warnings(:unknown_param_warning_type))
+            .to eq(["Unknown param 'bobby' and methods 'test1', 'test2'"])
+        end
+      end
+
+      context "when warning_type is :unknown_method_warning_type" do
+        it "returns 2 warnings" do
+          expect(parse_expression(expression_with_mixed_bad_params_and_methods).parameter_and_method_warnings(:unknown_method_warning_type))
+            .to eq(["Unknown methods 'test3', 'test4' used for on parameter 'color'"])
+        end
+      end
+
+      context "when there are invalid parameters" do
+        it "returns 2 warnings" do
+          expect(parse_expression(expression_with_bad_paramss).parameter_and_method_warnings).to eq(["Unknown param 'bobby'", "Unknown param 'bobby2'"])
+        end
+      end
+
+      context "when there are invalid methods" do
+        it "returns 2 warnings" do
+          expect(parse_expression(expression_with_bad_methods).parameter_and_method_warnings)
+            .to eq(["Unknown methods 'test1', 'test2', 'test3', 'test4' used for on parameter 'color'",
+                    "Unknown methods 'test1', 'test2' used for on parameter 'size'"])
+        end
+      end
+
+      context "when there are invalid parameters and methods" do
+        it "returns 2 warnings" do
+          expect(parse_expression(expression_with_bad_params_and_methods).parameter_and_method_warnings)
+            .to eq(["Unknown param 'bobby' and methods 'test1', 'test2'", "Unknown param 'bobby2' and methods 'test3', 'test4'"])
+        end
+      end
+    end
   end
 end

--- a/spec/lib/parameter_substitution/expression_spec.rb
+++ b/spec/lib/parameter_substitution/expression_spec.rb
@@ -103,20 +103,6 @@ describe ParameterSubstitution::Expression do
         end
       end
 
-      context "when warning_type is :unknown_param_warning_type" do
-        it "returns 1 warnings" do
-          expect(parse_expression(expression_with_mixed_bad_params_and_methods).parameter_and_method_warnings(:unknown_param_warning_type))
-            .to eq(["Unknown param 'bobby' and methods 'test1', 'test2'"])
-        end
-      end
-
-      context "when warning_type is :unknown_method_warning_type" do
-        it "returns 1 warnings" do
-          expect(parse_expression(expression_with_mixed_bad_params_and_methods).parameter_and_method_warnings(:unknown_method_warning_type))
-            .to eq(["Unknown methods 'test3', 'test4' used on parameter 'color'"])
-        end
-      end
-
       context "when there are invalid parameters" do
         it "returns 2 warnings" do
           expect(parse_expression(expression_with_bad_paramss).parameter_and_method_warnings).to eq(["Unknown param 'bobby'", "Unknown param 'bobby2'"])

--- a/spec/lib/parameter_substitution_spec.rb
+++ b/spec/lib/parameter_substitution_spec.rb
@@ -108,7 +108,7 @@ describe ParameterSubstitution do
         end
 
         context "when warning_type is :unknown_param_warning_type" do
-          it "returns 2 warnings" do
+          it "returns 1 warnings" do
             expect(ParameterSubstitution.find_warnings(expression_with_mixed_bad_params_and_methods,
                                                        mapping: default_mapping, warning_type: :unknown_param_warning_type))
               .to eq(["Unknown param 'bobby' and methods 'test1', 'test2'"])

--- a/spec/lib/parameter_substitution_spec.rb
+++ b/spec/lib/parameter_substitution_spec.rb
@@ -107,22 +107,6 @@ describe ParameterSubstitution do
           end
         end
 
-        context "when warning_type is :unknown_param_warning_type" do
-          it "returns 1 warnings" do
-            expect(ParameterSubstitution.find_warnings(expression_with_mixed_bad_params_and_methods,
-                                                       mapping: default_mapping, warning_type: :unknown_param_warning_type))
-              .to eq(["Unknown param 'bobby' and methods 'test1', 'test2'"])
-          end
-        end
-
-        context "when warning_type is :unknown_method_warning_type" do
-          it "returns 1 warning" do
-            expect(ParameterSubstitution.find_warnings(expression_with_mixed_bad_params_and_methods,
-                                                       mapping: default_mapping, warning_type: :unknown_method_warning_type))
-              .to eq(["Unknown methods 'test3', 'test4' used on parameter 'foo'"])
-          end
-        end
-
         context "when there are invalid parameters" do
           it "returns 2 warnings" do
             expect(ParameterSubstitution.find_warnings(expression_with_bad_paramss)).to eq(["Unknown param 'bobby'", "Unknown param 'bobby2'"])

--- a/spec/lib/parameter_substitution_spec.rb
+++ b/spec/lib/parameter_substitution_spec.rb
@@ -119,7 +119,7 @@ describe ParameterSubstitution do
           it "returns 1 warning" do
             expect(ParameterSubstitution.find_warnings(expression_with_mixed_bad_params_and_methods,
                                                        mapping: default_mapping, warning_type: :unknown_method_warning_type))
-              .to eq(["Unknown methods 'test3', 'test4' used for on parameter 'foo'"])
+              .to eq(["Unknown methods 'test3', 'test4' used on parameter 'foo'"])
           end
         end
 
@@ -132,8 +132,8 @@ describe ParameterSubstitution do
         context "when there are invalid methods" do
           it "returns 2 warnings" do
             expect(ParameterSubstitution.find_warnings(expression_with_bad_methods, mapping: default_mapping))
-              .to eq(["Unknown methods 'test1', 'test2', 'test3', 'test4' used for on parameter 'foo'",
-                      "Unknown methods 'test1', 'test2' used for on parameter 'black'"])
+              .to eq(["Unknown methods 'test1', 'test2', 'test3', 'test4' used on parameter 'foo'",
+                      "Unknown methods 'test1', 'test2' used on parameter 'black'"])
           end
         end
 

--- a/spec/lib/parameter_substitution_spec.rb
+++ b/spec/lib/parameter_substitution_spec.rb
@@ -101,9 +101,9 @@ describe ParameterSubstitution do
         let(:expression_with_mixed_bad_params_and_methods) { "<bobby.test1.test2><foo.test3.test4>" }
 
         context "when parameters are valid" do
-          it "returns 2 warnings" do
+          it "returns empty array" do
             expect(ParameterSubstitution.find_warnings(expression_with_valid_params, mapping: default_mapping))
-              .to eq(nil)
+              .to eq([])
           end
         end
 
@@ -116,7 +116,7 @@ describe ParameterSubstitution do
         end
 
         context "when warning_type is :unknown_method_warning_type" do
-          it "returns 2 warnings" do
+          it "returns 1 warning" do
             expect(ParameterSubstitution.find_warnings(expression_with_mixed_bad_params_and_methods,
                                                        mapping: default_mapping, warning_type: :unknown_method_warning_type))
               .to eq(["Unknown methods 'test3', 'test4' used for on parameter 'foo'"])

--- a/spec/lib/parameter_substitution_spec.rb
+++ b/spec/lib/parameter_substitution_spec.rb
@@ -92,6 +92,41 @@ describe ParameterSubstitution do
           expect(ParameterSubstitution.find_formatters(expression, mapping: mapping)).to eq(['blank_if_nil', 'downcase'])
         end
       end
+
+      context '#find_warnings' do
+        let(:expression_with_valid_params) { "<foo>" }
+        let(:expression_with_bad_paramss) { "<bobby><bobby2>" }
+        let(:expression_with_bad_methods) { "<foo.test1.test2><foo.test3.test4><black.test1.test2>" }
+        let(:expression_with_bad_params_and_methods) { "<bobby.test1.test2><bobby2.test3.test4>" }
+
+        context "when parameters are valid" do
+          it "returns 2 warnings" do
+            expect(ParameterSubstitution.find_warnings(expression_with_valid_params, mapping: default_mapping))
+              .to eq(nil)
+          end
+        end
+
+        context "when there are invalid parameters" do
+          it "returns 2 warnings" do
+            expect(ParameterSubstitution.find_warnings(expression_with_bad_paramss)).to eq(["Unknown param 'bobby'", "Unknown param 'bobby2'"])
+          end
+        end
+
+        context "when there are invalid methods" do
+          it "returns 2 warnings" do
+            expect(ParameterSubstitution.find_warnings(expression_with_bad_methods, mapping: default_mapping))
+              .to eq(["Unknown methods 'test1', 'test2', 'test3', 'test4' used for on parameter 'foo'",
+                      "Unknown methods 'test1', 'test2' used for on parameter 'black'"])
+          end
+        end
+
+        context "when there are invalid parameters and methods" do
+          it "returns 2 warnings" do
+            expect(ParameterSubstitution.find_warnings(expression_with_bad_params_and_methods))
+              .to eq(["Unknown param 'bobby' and methods 'test1', 'test2'", "Unknown param 'bobby2' and methods 'test3', 'test4'"])
+          end
+        end
+      end
     end
 
     it "handle simple go right cases" do

--- a/spec/lib/parameter_substitution_spec.rb
+++ b/spec/lib/parameter_substitution_spec.rb
@@ -98,11 +98,28 @@ describe ParameterSubstitution do
         let(:expression_with_bad_paramss) { "<bobby><bobby2>" }
         let(:expression_with_bad_methods) { "<foo.test1.test2><foo.test3.test4><black.test1.test2>" }
         let(:expression_with_bad_params_and_methods) { "<bobby.test1.test2><bobby2.test3.test4>" }
+        let(:expression_with_mixed_bad_params_and_methods) { "<bobby.test1.test2><foo.test3.test4>" }
 
         context "when parameters are valid" do
           it "returns 2 warnings" do
             expect(ParameterSubstitution.find_warnings(expression_with_valid_params, mapping: default_mapping))
               .to eq(nil)
+          end
+        end
+
+        context "when warning_type is :unknown_param_warning_type" do
+          it "returns 2 warnings" do
+            expect(ParameterSubstitution.find_warnings(expression_with_mixed_bad_params_and_methods,
+                                                       mapping: default_mapping, warning_type: :unknown_param_warning_type))
+              .to eq(["Unknown param 'bobby' and methods 'test1', 'test2'"])
+          end
+        end
+
+        context "when warning_type is :unknown_method_warning_type" do
+          it "returns 2 warnings" do
+            expect(ParameterSubstitution.find_warnings(expression_with_mixed_bad_params_and_methods,
+                                                       mapping: default_mapping, warning_type: :unknown_method_warning_type))
+              .to eq(["Unknown methods 'test3', 'test4' used for on parameter 'foo'"])
           end
         end
 


### PR DESCRIPTION
Allows errors to be aggregated by parameter and accessed externally. 